### PR TITLE
[CHORE] DB에 food, criterion 컬럼 추가 반영

### DIFF
--- a/logs/log.json
+++ b/logs/log.json
@@ -1,0 +1,7 @@
+{"@timestamp":"2023-02-16T09:28:53.303Z","log.level":"debug","message":"[GET] /home || Request Body: {\"goalContent\":\"하루에 단백질\",\"isMore\":true} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:29:05.239Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"isMore\":true} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:11.653Z","log.level":"debug","message":"[POST] /goal/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:30.839Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:43.934Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:52.937Z","log.level":"debug","message":"[POST] /goal/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:32:02.171Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Daily_Achieved_History {
 
 model Goal {
   goalId                 Int                      @id @default(autoincrement())
-  goalContent            String                   @db.VarChar(15)
+  goalContent            String?                  @db.VarChar(15)
   isMore                 Boolean
   isOngoing              Boolean                  @default(true)
   totalCount             Int                      @default(0)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Daily_Achieved_History {
 
 model Goal {
   goalId                 Int                      @id @default(autoincrement())
-  goalContent            String                   @db.VarChar(200)
+  goalContent            String                   @db.VarChar(15)
   isMore                 Boolean
   isOngoing              Boolean                  @default(true)
   totalCount             Int                      @default(0)
@@ -36,6 +36,8 @@ model Goal {
   keptAt                 DateTime?
   isAchieved             Boolean                  @default(false)
   writerId               Int
+  criterion              String?                  @db.VarChar(20)
+  food                   String?                  @db.VarChar(15)
   Daily_Achieved_History Daily_Achieved_History[]
   User                   User                     @relation(fields: [writerId], references: [userId], onDelete: Cascade, map: "writer_id")
 }

--- a/src/interfaces/goal/CreateGoalDTO.ts
+++ b/src/interfaces/goal/CreateGoalDTO.ts
@@ -1,6 +1,5 @@
 export interface CreateGoalDTO {
-  goalContent: string;
-  criterion: string;
   food: string;
+  criterion: string;
   isMore: boolean;
 }

--- a/src/interfaces/goal/CreateGoalDTO.ts
+++ b/src/interfaces/goal/CreateGoalDTO.ts
@@ -1,4 +1,6 @@
 export interface CreateGoalDTO {
   goalContent: string;
+  criterion: string;
+  food: string;
   isMore: boolean;
 }

--- a/src/interfaces/goal/UpdateGoalDTO.ts
+++ b/src/interfaces/goal/UpdateGoalDTO.ts
@@ -1,3 +1,5 @@
 export interface UpdateGoalDTO {
   goalContent: string; 
+  criterion: string;
+  food: string;
 }

--- a/src/interfaces/goal/UpdateGoalDTO.ts
+++ b/src/interfaces/goal/UpdateGoalDTO.ts
@@ -1,5 +1,4 @@
 export interface UpdateGoalDTO {
-  goalContent: string; 
-  criterion: string;
   food: string;
+  criterion: string;
 }

--- a/src/router/goalRouter.ts
+++ b/src/router/goalRouter.ts
@@ -16,7 +16,8 @@ router.post("/achieve/:goalId", goalController.achieveGoal);
 router.post(
   "/:goalId", 
   [
-    body("goalContent").trim().notEmpty(),
+    body("food").trim().notEmpty(), 
+    body("criterion").trim().notEmpty(),
   ],
   auth, 
   goalController.updateGoal
@@ -27,7 +28,8 @@ router.delete("/:goalId", auth, goalController.deleteGoal);
 router.post(
   "/", 
   [
-    body("goalContent").trim().notEmpty(), 
+    body("food").trim().notEmpty(), 
+    body("criterion").trim().notEmpty(),
     body("isMore").notEmpty(),
   ], 
   auth, 

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -60,11 +60,10 @@ const getHomeGoalsByUserId = async (currentMonth: string, userId: number) => {
 const createGoal = async (userId: number, createGoalDTO: CreateGoalDTO, startedAt: string) => {
   const data = await prisma.goal.create({
     data: {
-      goalContent: createGoalDTO.goalContent,
-      criterion: createGoalDTO.criterion,
       food: createGoalDTO.food,
+      criterion: createGoalDTO.criterion,
       isMore: createGoalDTO.isMore,
-      writerId:  userId,
+      writerId: userId,
       startedAt,
       totalCount: 0
     },
@@ -90,9 +89,8 @@ const updateGoal = async (goalId: number, updateGoalDTO: UpdateGoalDTO) => {
       goalId
     },
     data: {
-      goalContent: updateGoalDTO.goalContent,
-      criterion: updateGoalDTO.criterion,
-      food: updateGoalDTO.food
+      food: updateGoalDTO.food,
+      criterion: updateGoalDTO.criterion
     },
   });
   return data.goalId;

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -61,6 +61,8 @@ const createGoal = async (userId: number, createGoalDTO: CreateGoalDTO, startedA
   const data = await prisma.goal.create({
     data: {
       goalContent: createGoalDTO.goalContent,
+      criterion: createGoalDTO.criterion,
+      food: createGoalDTO.food,
       isMore: createGoalDTO.isMore,
       writerId:  userId,
       startedAt,

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -91,6 +91,8 @@ const updateGoal = async (goalId: number, updateGoalDTO: UpdateGoalDTO) => {
     },
     data: {
       goalContent: updateGoalDTO.goalContent,
+      criterion: updateGoalDTO.criterion,
+      food: updateGoalDTO.food
     },
   });
   return data.goalId;


### PR DESCRIPTION
### 구현 내용
- 기존의 목표 추가, 그리고 목표 수정 api 내부에서 음식 이름과 기준으로 나누어 목표를 설정할 수 있도록 수정하였습니다.
- 테이블상의 `goalContent`는 에러를 피하기 위해 잠시 not null 체크를 해제해둔 상태인데, DB 밀어도 괜찮은 것으로 판단되면 바로 goalContent도 밀겠습니다~!

### To-do
- [x] 목표 추가 및 수정 시 음식 이름과 기준을 한꺼번에 POST 할 수 있도록 수정
- [ ] 목표 추가 시 같은 음식 혹은 기준 (그걸 판가름하는 기준은 아직 안나왔음!) 은 작성 못하도록 
