### PR TITLE
[FEAT] 마이페이지 api (마이페이지 중 메인 뷰) 구현 

### DIFF
--- a/logs/log.json
+++ b/logs/log.json
@@ -1,7 +1,0 @@
-{"@timestamp":"2023-02-16T09:28:53.303Z","log.level":"debug","message":"[GET] /home || Request Body: {\"goalContent\":\"하루에 단백질\",\"isMore\":true} uid: 89","ecs":{"version":"1.6.0"}}
-{"@timestamp":"2023-02-16T09:29:05.239Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"isMore\":true} uid: 89","ecs":{"version":"1.6.0"}}
-{"@timestamp":"2023-02-16T09:31:11.653Z","log.level":"debug","message":"[POST] /goal/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
-{"@timestamp":"2023-02-16T09:31:30.839Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
-{"@timestamp":"2023-02-16T09:31:43.934Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
-{"@timestamp":"2023-02-16T09:31:52.937Z","log.level":"debug","message":"[POST] /goal/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
-{"@timestamp":"2023-02-16T09:32:02.171Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}

--- a/logs/log.json
+++ b/logs/log.json
@@ -1,0 +1,7 @@
+{"@timestamp":"2023-02-16T09:28:53.303Z","log.level":"debug","message":"[GET] /home || Request Body: {\"goalContent\":\"하루에 단백질\",\"isMore\":true} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:29:05.239Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"isMore\":true} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:11.653Z","log.level":"debug","message":"[POST] /goal/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:30.839Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 단백질\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:43.934Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:31:52.937Z","log.level":"debug","message":"[POST] /goal/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}
+{"@timestamp":"2023-02-16T09:32:02.171Z","log.level":"debug","message":"[GET] /history/808 || Request Body: {\"goalContent\":\"하루에 달걀\",\"criterion\":\"하루에\",\"food\":\"달걀\"} uid: 89","ecs":{"version":"1.6.0"}}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,7 +28,7 @@ model Daily_Achieved_History {
 
 model Goal {
   goalId                 Int                      @id @default(autoincrement())
-  goalContent            String                   @db.VarChar(200)
+  goalContent            String                   @db.VarChar(15)
   isMore                 Boolean
   isOngoing              Boolean                  @default(true)
   totalCount             Int                      @default(0)
@@ -36,6 +36,8 @@ model Goal {
   keptAt                 DateTime?
   isAchieved             Boolean                  @default(false)
   writerId               Int
+  criterion              String?                  @db.VarChar(20)
+  food                   String?                  @db.VarChar(15)
   Daily_Achieved_History Daily_Achieved_History[]
   User                   User                     @relation(fields: [writerId], references: [userId], onDelete: Cascade, map: "writer_id")
 }

--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -42,7 +42,7 @@ export default {
   ACHIEVE_GOAL_FAIL_FOR_DOUBLE_ACHIEVE: "달성한 목표를 또 달성하려는 시도입니다",
 
   // 마이페이지
-  GET_ACCOUNT_INFO_SUCCESS_FOR_MYPAGE: "마이페이지 계정 정보 조회 성공",
+  GET_ACCOUNT_INFO_SUCCESS_FOR_MYPAGE: "마이페이지 메인 뷰 조회 성공",
   GET_GOALS_SUCCESS_FOR_MYPAGE: "마이페이지 뷰 조회 성공",
 
   // 기록뷰

--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -42,6 +42,7 @@ export default {
   ACHIEVE_GOAL_FAIL_FOR_DOUBLE_ACHIEVE: "달성한 목표를 또 달성하려는 시도입니다",
 
   // 마이페이지
+  GET_ACCOUNT_INFO_SUCCESS_FOR_MYPAGE: "마이페이지 계정 정보 조회 성공",
   GET_GOALS_SUCCESS_FOR_MYPAGE: "마이페이지 뷰 조회 성공",
 
   // 기록뷰

--- a/src/controller/mypageController.ts
+++ b/src/controller/mypageController.ts
@@ -5,6 +5,32 @@ import { mypageService } from "../service";
 import slack from "../modules/slack";
 import { debugLog, errorLog } from "../logger/logger";
 
+const getAccountInfoByUserId = async (req: Request, res: Response) => {
+  const userId = req.user.userId;
+  if(!userId) {
+    return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
+  }
+
+  try {
+    const accountInfo = await mypageService.getAccountInfoForMyPage(+userId);
+    const keptGoalsCount = await mypageService.getKeptGoalsCountForMyPage(+userId);
+    const data = {
+      "name": accountInfo?.name,
+      "email": accountInfo?.email,
+      "keptGoalsCount": keptGoalsCount
+    }
+    const randInt = (min: number, max: number) => {
+      return Math.floor(Math.random() * (max - min)) + min;
+    }
+    if (accountInfo?.name === null || accountInfo?.name === undefined) {
+      data.name = "user" + randInt(101, 999)
+    }
+    return res.status(sc.OK).send(success(sc.OK, rm.GET_ACCOUNT_INFO_SUCCESS_FOR_MYPAGE, data));
+  } catch (error) {
+    return res.status(sc.INTERNAL_SERVER_ERROR).send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR));
+  }
+}
+
 const sortType = {
   ALL: "all",
   MORE: "more",
@@ -42,6 +68,7 @@ const getKeptGoalsByUserId = async (req: Request, res: Response) => {
 };
 
 const mypageController = {
+  getAccountInfoByUserId,
   getKeptGoalsByUserId
 }
 

--- a/src/controller/mypageController.ts
+++ b/src/controller/mypageController.ts
@@ -11,7 +11,7 @@ const sortType = {
   LESS: "less"
 };
 
-const getMypageByUserId = async (req: Request, res: Response) => {
+const getKeptGoalsByUserId = async (req: Request, res: Response) => {
   const userId = req.user.userId;
 
   const sort = req.query.sort as string;
@@ -26,7 +26,7 @@ const getMypageByUserId = async (req: Request, res: Response) => {
 
   try {
   
-    const foundGoals = await mypageService.getGoalsForMypage(+userId, sort as string);
+    const foundGoals = await mypageService.getKeptGoalsForMypage(+userId, sort as string);
     
     debugLog(req.originalUrl, req.method, req.body, req.user?.userId);
     return res.status(sc.OK).send(success(sc.OK, rm.GET_GOALS_SUCCESS_FOR_MYPAGE, { "goals": foundGoals, "goalCount": foundGoals.length }));
@@ -42,7 +42,7 @@ const getMypageByUserId = async (req: Request, res: Response) => {
 };
 
 const mypageController = {
-  getMypageByUserId
+  getKeptGoalsByUserId
 }
 
 export default mypageController;

--- a/src/controller/mypageController.ts
+++ b/src/controller/mypageController.ts
@@ -19,11 +19,8 @@ const getAccountInfoByUserId = async (req: Request, res: Response) => {
       "email": accountInfo?.email,
       "keptGoalsCount": keptGoalsCount
     }
-    const randInt = (min: number, max: number) => {
-      return Math.floor(Math.random() * (max - min)) + min;
-    }
     if (accountInfo?.name === null || accountInfo?.name === undefined) {
-      data.name = "user" + randInt(101, 999)
+      data.name = "유저 실명을 받아오지 못했습니다."
     }
     return res.status(sc.OK).send(success(sc.OK, rm.GET_ACCOUNT_INFO_SUCCESS_FOR_MYPAGE, data));
   } catch (error) {

--- a/src/interfaces/goal/CreateGoalDTO.ts
+++ b/src/interfaces/goal/CreateGoalDTO.ts
@@ -1,4 +1,6 @@
 export interface CreateGoalDTO {
   goalContent: string;
+  criterion: string;
+  food: string;
   isMore: boolean;
 }

--- a/src/interfaces/goal/UpdateGoalDTO.ts
+++ b/src/interfaces/goal/UpdateGoalDTO.ts
@@ -1,3 +1,5 @@
 export interface UpdateGoalDTO {
   goalContent: string; 
+  criterion: string;
+  food: string;
 }

--- a/src/router/mypageRouter.ts
+++ b/src/router/mypageRouter.ts
@@ -4,6 +4,6 @@ import { mypageController } from "../controller";
 const router:Router = Router();
 
 router.get("/", mypageController.getKeptGoalsByUserId);
-router.get("/account", mypageController.getAccountInfoByUserId);
+router.get("/main", mypageController.getAccountInfoByUserId);
 
 export default router;

--- a/src/router/mypageRouter.ts
+++ b/src/router/mypageRouter.ts
@@ -3,6 +3,6 @@ import { mypageController } from "../controller";
 
 const router:Router = Router();
 
-router.get("/", mypageController.getMypageByUserId);
+router.get("/", mypageController.getKeptGoalsByUserId);
 
 export default router;

--- a/src/router/mypageRouter.ts
+++ b/src/router/mypageRouter.ts
@@ -4,5 +4,6 @@ import { mypageController } from "../controller";
 const router:Router = Router();
 
 router.get("/", mypageController.getKeptGoalsByUserId);
+router.get("/account", mypageController.getAccountInfoByUserId);
 
 export default router;

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -61,6 +61,8 @@ const createGoal = async (userId: number, createGoalDTO: CreateGoalDTO, startedA
   const data = await prisma.goal.create({
     data: {
       goalContent: createGoalDTO.goalContent,
+      criterion: createGoalDTO.criterion,
+      food: createGoalDTO.food,
       isMore: createGoalDTO.isMore,
       writerId:  userId,
       startedAt,

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -91,6 +91,8 @@ const updateGoal = async (goalId: number, updateGoalDTO: UpdateGoalDTO) => {
     },
     data: {
       goalContent: updateGoalDTO.goalContent,
+      criterion: updateGoalDTO.criterion,
+      food: updateGoalDTO.food
     },
   });
   return data.goalId;

--- a/src/service/mypageService.ts
+++ b/src/service/mypageService.ts
@@ -23,7 +23,7 @@ const getKeptGoalsCountForMyPage = async(userId: number) => {
   });
   keptGoals.map((goal) => {
     if (goal.keptAt !== null) { 
-      keptGoalsCount = keptGoalsCount+1; 
+      ++keptGoalsCount; 
     }
   });
   return keptGoalsCount;

--- a/src/service/mypageService.ts
+++ b/src/service/mypageService.ts
@@ -3,7 +3,7 @@ import date from "../modules/date";
 
 const prisma = new PrismaClient();
 
-const getGoalsForMypage = async (userId: number, sort: string) => {
+const getKeptGoalsForMypage = async (userId: number, sort: string) => {
   let goals;
   let isMore;
 
@@ -61,7 +61,7 @@ const getGoalsForMypage = async (userId: number, sort: string) => {
 };
 
 const mypageService = {
-  getGoalsForMypage,
+  getKeptGoalsForMypage,
 };
 
 export default mypageService

--- a/src/service/mypageService.ts
+++ b/src/service/mypageService.ts
@@ -3,6 +3,32 @@ import date from "../modules/date";
 
 const prisma = new PrismaClient();
 
+const getAccountInfoForMyPage = async(userId: number) => {
+  const accountInfo = await prisma.user.findUnique({
+    where: {
+      userId: userId
+    }
+  });
+
+  return accountInfo;
+};
+
+const getKeptGoalsCountForMyPage = async(userId: number) => {
+  let keptGoalsCount = 0;
+
+  const keptGoals = await prisma.goal.findMany({
+    where: {
+      writerId: userId,
+    }    
+  });
+  keptGoals.map((goal) => {
+    if (goal.keptAt !== null) { 
+      keptGoalsCount = keptGoalsCount+1; 
+    }
+  });
+  return keptGoalsCount;
+}
+
 const getKeptGoalsForMypage = async (userId: number, sort: string) => {
   let goals;
   let isMore;
@@ -61,6 +87,8 @@ const getKeptGoalsForMypage = async (userId: number, sort: string) => {
 };
 
 const mypageService = {
+  getAccountInfoForMyPage,
+  getKeptGoalsCountForMyPage,
   getKeptGoalsForMypage,
 };
 


### PR DESCRIPTION
### 구현 내용
---
마이페이지 중 메인 뷰에서 유저 실명, 이메일 주소, 보관한 목표 개수를 조회할 수 있도록 하는 api를 구현했습니다.

* [피그마 GUI](https://www.figma.com/file/leIiEyWDozQIPZnsJRVc9Q/GUI?node-id=1253%3A12934&t=M3HccvTXTTFwmsnf-0)에서 마이페이지 관련 뷰가 메인, 계정 정보, 보관 세 가지로 나뉘는 것을 확인한 후,
마이페이지 중에서도 메인 뷰 조회에 사용될 api로 구분하여 구현해야 하겠다고 판단되어서

1. 기존 마이페이지 (보관한 목표 열람) 관련 함수들의 이름을 '보관한 목표 관련'임이 드러나게 바꾸었으며
2. 컨트롤러와 서비스를 따로 분리하지 않고 `mypageController`와 `mypageService` 내에서 로직을 작성하였습니다. 

### To-do

- [x] 유저 실명 정보를 못찾을 경우에는 마이페이지 조회할때마다 `user+난수`에서 난수가 새로 생성되는데 이거 상관없는지 물어보고 반영하기 -> 기획: 난수 값은 고정되어야 함
  - 마이페이지 api 단에서는 일단 터치 x하는 것으로 
