### PR TITLE
[FIX] 목표 수정시 기준/음식 중 일부만 수정 또는 삭제되는 케이스 분기처리 생략

### DIFF
--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -102,23 +102,6 @@ const updateGoal = async (req: Request, res: Response) => {
 
   try {
 
-    // // 기준만 수정 혹은 삭제되는 케이스
-    // if((food === null && criterion !== "" && typeof criterion === "string") 
-    //     || (food === null && criterion === "")) {
-    //   const updatedGoalId = await goalService.updateCriterion(+goalId, updateGoalDTO);
-    //   return res
-    //     .status(sc.OK)
-    //     .send(success(sc.OK, rm.UPDATE_GOAL_SUCCESS, { "goalId": updatedGoalId }));
-    // }
-
-    // // 음식만 수정되는 케이스
-    // if(typeof food === "string" && food !== "" && criterion === null) { // criterion == ""
-    //   const updatedGoalId = await goalService.updateFood(+goalId, updateGoalDTO);
-    //   return res
-    //     .status(sc.OK)
-    //     .send(success(sc.OK, rm.UPDATE_GOAL_SUCCESS, { "goalId": updatedGoalId }));
-    // }
-
     // 음식, 기준 둘 다 수정하거나 음식을 수정하고 기준 삭제한 케이스
     const updatedGoalId = await goalService.updateGoal(+goalId, updateGoalDTO);
   

--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -93,11 +93,15 @@ const deleteGoal = async (req: Request, res: Response) => {
 };
 
 const updateGoal = async (req: Request, res: Response) => {
-
-  const food = req.body.food;
+  const error = validationResult(req);
+  if(!error.isEmpty()) {
+    return res
+      .status(sc.BAD_REQUEST)
+      .send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
+  }
   const criterion = req.body.criterion;
 
-  if (criterion === " " || food === "") {
+  if (criterion === null) {
     return res
       .status(sc.BAD_REQUEST)
       .send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));

--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -102,24 +102,24 @@ const updateGoal = async (req: Request, res: Response) => {
 
   try {
 
-    // 기준만 수정 혹은 삭제되는 케이스
-    if((food === null && criterion !== "" && typeof criterion === "string") 
-        || (food === null && criterion === "")) {
-      const updatedGoalId = await goalService.updateCriterion(+goalId, updateGoalDTO);
-      return res
-        .status(sc.OK)
-        .send(success(sc.OK, rm.UPDATE_GOAL_SUCCESS, { "goalId": updatedGoalId }));
-    }
+    // // 기준만 수정 혹은 삭제되는 케이스
+    // if((food === null && criterion !== "" && typeof criterion === "string") 
+    //     || (food === null && criterion === "")) {
+    //   const updatedGoalId = await goalService.updateCriterion(+goalId, updateGoalDTO);
+    //   return res
+    //     .status(sc.OK)
+    //     .send(success(sc.OK, rm.UPDATE_GOAL_SUCCESS, { "goalId": updatedGoalId }));
+    // }
 
-    // 음식만 수정되는 케이스
-    if(typeof food === "string" && food !== "" && criterion === null) { // criterion == ""
-      const updatedGoalId = await goalService.updateFood(+goalId, updateGoalDTO);
-      return res
-        .status(sc.OK)
-        .send(success(sc.OK, rm.UPDATE_GOAL_SUCCESS, { "goalId": updatedGoalId }));
-    }
+    // // 음식만 수정되는 케이스
+    // if(typeof food === "string" && food !== "" && criterion === null) { // criterion == ""
+    //   const updatedGoalId = await goalService.updateFood(+goalId, updateGoalDTO);
+    //   return res
+    //     .status(sc.OK)
+    //     .send(success(sc.OK, rm.UPDATE_GOAL_SUCCESS, { "goalId": updatedGoalId }));
+    // }
 
-    // 음식, 기준 둘 다 수정하거나 음식을 수정하고 기준 삭제한 케이서
+    // 음식, 기준 둘 다 수정하거나 음식을 수정하고 기준 삭제한 케이스
     const updatedGoalId = await goalService.updateGoal(+goalId, updateGoalDTO);
   
     return res

--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -91,7 +91,7 @@ const updateGoal = async (req: Request, res: Response) => {
   const food = req.body.food;
   const criterion = req.body.criterion;
 
-  if (criterion === " " || food === "" || food === " ") {
+  if (criterion === " " || food === "") {
     return res
       .status(sc.BAD_REQUEST)
       .send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));

--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -91,7 +91,7 @@ const updateGoal = async (req: Request, res: Response) => {
   const food = req.body.food;
   const criterion = req.body.criterion;
 
-  if (criterion === " " || food === "") {
+  if (criterion === " " || food === "" || food === " ") {
     return res
       .status(sc.BAD_REQUEST)
       .send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));

--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -91,7 +91,7 @@ const updateGoal = async (req: Request, res: Response) => {
   const food = req.body.food;
   const criterion = req.body.criterion;
 
-  if (criterion === " ") {
+  if (criterion === " " || food === "") {
     return res
       .status(sc.BAD_REQUEST)
       .send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));

--- a/src/router/goalRouter.ts
+++ b/src/router/goalRouter.ts
@@ -15,7 +15,6 @@ router.post(
   "/:goalId", 
   [
     body("food").trim().notEmpty(), 
-    body("criterion").trim().notEmpty(),
   ],
   goalController.updateGoal
 );

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -31,13 +31,13 @@ const updateGoal = async (goalId: number, updateGoalDTO: UpdateGoalDTO) => {
   return await goalRepository.updateGoal(goalId, updateGoalDTO);
 };
 
-const updateFood = async(goalId: number, updateGoalDTO: UpdateGoalDTO) => {
-  return await goalRepository.updateFood(goalId, updateGoalDTO);  
-};
+// const updateFood = async(goalId: number, updateGoalDTO: UpdateGoalDTO) => {
+//   return await goalRepository.updateFood(goalId, updateGoalDTO);  
+// };
 
-const updateCriterion = async(goalId: number, updateGoalDTO: UpdateGoalDTO) => {
-  return await goalRepository.updateCriterion(goalId, updateGoalDTO);  
-};
+// const updateCriterion = async(goalId: number, updateGoalDTO: UpdateGoalDTO) => {
+//   return await goalRepository.updateCriterion(goalId, updateGoalDTO);  
+// };
 
 const keepGoal = async (goalId: number, isOngoing: boolean, keptAt: string) => {
   return await goalRepository.keepGoal(goalId, isOngoing, keptAt);    
@@ -151,8 +151,8 @@ const goalService = {
   getGoalByGoalId,
   createGoal,
   deleteGoal,
-  updateFood,
-  updateCriterion,
+  // updateFood,
+  // updateCriterion,
   updateGoal,
   getHomeGoalsByUserId,
   achieveGoal,

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -31,14 +31,6 @@ const updateGoal = async (goalId: number, updateGoalDTO: UpdateGoalDTO) => {
   return await goalRepository.updateGoal(goalId, updateGoalDTO);
 };
 
-// const updateFood = async(goalId: number, updateGoalDTO: UpdateGoalDTO) => {
-//   return await goalRepository.updateFood(goalId, updateGoalDTO);  
-// };
-
-// const updateCriterion = async(goalId: number, updateGoalDTO: UpdateGoalDTO) => {
-//   return await goalRepository.updateCriterion(goalId, updateGoalDTO);  
-// };
-
 const keepGoal = async (goalId: number, isOngoing: boolean, keptAt: string) => {
   return await goalRepository.keepGoal(goalId, isOngoing, keptAt);    
 }
@@ -151,8 +143,6 @@ const goalService = {
   getGoalByGoalId,
   createGoal,
   deleteGoal,
-  // updateFood,
-  // updateCriterion,
   updateGoal,
   getHomeGoalsByUserId,
   achieveGoal,


### PR DESCRIPTION
- 향후 업데이트가 진행된다면 기존에 서버 노션에 적혀있던 대로 케이스별 분기처리를 적용할 수도 있겠으나, 
   ![image](https://user-images.githubusercontent.com/82032418/235849453-5f89e7c3-0222-4d0f-a091-25f43d29b02c.png)

- 우선은 클라분들께서 음식, 기준의 변경 여부와 관계없이 request body로 모두 보내주신다고 하셨기 때문에,
음식과 기준에는 항상 문자열이 들어올 것이라고 판단하고 (기준이 삭제된다면 `""` 들어옴)
기존 분기처리를 주석처리만 해두었습니다