### PR TITLE
[HOTFIX] 기준 빈문자열, 음식 문자열일 경우 목표 두번 등록되는 에러 수정

### DIFF
--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -35,7 +35,10 @@ const createGoal = async (req: Request, res: Response) => {
 
 
     if(criterion === "" && typeof food === "string") {
-      await goalService.createFoodGoal(userId, createGoalDTO, startedAt);
+      const data = await goalService.createFoodGoal(userId, createGoalDTO, startedAt);
+      return res
+      .status(sc.OK)
+      .send(success(sc.OK, rm.CREATE_GOAL_SUCCESS, data));
     }
 
     const data = await goalService.createGoal(userId, createGoalDTO, startedAt);

--- a/src/controller/goalController.ts
+++ b/src/controller/goalController.ts
@@ -33,14 +33,6 @@ const createGoal = async (req: Request, res: Response) => {
     const createGoalDTO: CreateGoalDTO = req.body; 
     const startedAt = date.getCurrentDatePlus9h(now);
 
-
-    if(criterion === "" && typeof food === "string") {
-      const data = await goalService.createFoodGoal(userId, createGoalDTO, startedAt);
-      return res
-      .status(sc.OK)
-      .send(success(sc.OK, rm.CREATE_GOAL_SUCCESS, data));
-    }
-
     const data = await goalService.createGoal(userId, createGoalDTO, startedAt);
 
     if (data == goalError.MAX_GOAL_COUNT_ERROR) {

--- a/src/repository/goalRepository.ts
+++ b/src/repository/goalRepository.ts
@@ -74,36 +74,7 @@ const createGoal = async (userId: number, createGoalDTO: CreateGoalDTO, startedA
   const data = await prisma.goal.create({
     data: {
       food: createGoalDTO.food,
-      criterion: createGoalDTO.criterion,
-      isMore: createGoalDTO.isMore,
-      writerId: userId,
-      startedAt,
-      totalCount: 0
-    }, 
-  });
-  const goalId = data.goalId
-  
-  return { goalId };
-  
-};
-
-const createFoodGoal = async (userId: number, createGoalDTO: CreateGoalDTO, startedAt: string) => {
-  
-  const ongoingGoalCount = await prisma.goal.count({
-    where: {
-      writerId: userId,
-      isOngoing: true
-    }
-  }); 
-
-  if (ongoingGoalCount >= 3) {
-    return goalError.MAX_GOAL_COUNT_ERROR;
-  }
-
-  const data = await prisma.goal.create({
-    data: {
-      food: createGoalDTO.food,
-      criterion: null,
+      criterion: createGoalDTO.criterion === "" ? null : createGoalDTO.criterion,
       isMore: createGoalDTO.isMore,
       writerId: userId,
       startedAt,
@@ -273,7 +244,6 @@ const sortKeptGoals = (keptGoals: Goal[], now: string) => {
 const goalRepository = {
   findGoalByGoalId,
   createGoal,
-  createFoodGoal,
   deleteGoal,
   updateFood,
   updateCriterion,

--- a/src/service/goalService.ts
+++ b/src/service/goalService.ts
@@ -23,10 +23,6 @@ const createGoal = async (userId: number, createGoalDTO: CreateGoalDTO, startedA
   return await goalRepository.createGoal(userId, createGoalDTO, startedAt);
 };
 
-const createFoodGoal = async(userId: number,createGoalDTO: CreateGoalDTO, startedAt: string) => {
-  return await goalRepository.createFoodGoal(userId, createGoalDTO, startedAt);
-};
-
 const deleteGoal = async (goalId: number) => {
   return await goalRepository.deleteGoal(goalId);
 };
@@ -146,7 +142,6 @@ const isAchievedToday = (achievedAt: Date | null, isAchieved: boolean, now: stri
 const goalService = {
   getGoalByGoalId,
   createGoal,
-  createFoodGoal,
   deleteGoal,
   updateGoal,
   getHomeGoalsByUserId,


### PR DESCRIPTION
- 목표 추가 api 분기처리를 수정하면서 return문을 생략한 구간이 있었는데, 그 결과 목표가 두 번 등록되어 버리는 문제가 발생해서 해당 부분 수정했습니다!